### PR TITLE
Add HTTP transport for hosted MCP deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.venv
+.pytest_cache
+__pycache__
+*.pyc
+tests
+demo.gif
+Dockerfile
+.dockerignore
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY axle_mcp_server ./axle_mcp_server
+
+RUN pip install --no-cache-dir ".[http]"
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["axle-mcp-server", "--http"]

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ manipulation tools to AI agents.
 1. Create a free API key:
    [https://axle.axiommath.ai/app/console](https://axle.axiommath.ai/app/console).
 
-2. Add the MCP server to your client:
+2. Add the MCP server to your client using one of the options below.
 
-**Claude Code:**
+### Claude Code
 
 Replace `your_api_key_here` with the API key you created in step 1:
 ```bash
 claude mcp add axle -e AXLE_API_KEY=your_api_key_here -- uvx --from axiom-axle-mcp axle-mcp-server
 ```
 
-**Other MCP clients (Cursor, Windsurf, Claude Desktop, VS Code, Cline, etc.):**
+### Other MCP clients (Cursor, Windsurf, Claude Desktop, VS Code, Cline, etc.)
 
 Add the following to your client's MCP config file. Replace `your_api_key_here`
 with the API key you created in step 1:
@@ -39,3 +39,33 @@ with the API key you created in step 1:
   }
 }
 ```
+
+### Claude (web / desktop / mobile)
+
+A hosted instance runs at `https://mcp.axiommath.ai/mcp`. You only need to do
+this once; after setup, Axle is available in every future conversation.
+
+1. Open Claude and click your profile avatar → **Settings**.
+2. Go to the **Connectors** tab.
+3. Scroll to the bottom of the page and click **Add custom connector**.
+4. Fill in:
+   - **Name:** `Axle`
+   - **Remote MCP server URL:** `https://mcp.axiommath.ai/mcp`
+5. Expand **Advanced settings** and paste the API key from step 1 as the
+   **OAuth Client ID / Bearer token**.
+6. Click **Add**.
+7. In any chat, open the tools menu (the **+** or paperclip icon in the
+   composer) → **Connectors** → toggle **Axle** on. You should see the Axle
+   tools listed.
+
+### ChatGPT (web / mobile)
+
+Custom MCP connectors require a paid plan (Plus, Pro, Business, or Enterprise).
+
+1. Open ChatGPT → **Settings** → **Connectors**.
+2. Click **Add** (or **Create**) and choose the custom / MCP option.
+3. Fill in:
+   - **Name:** `Axle`
+   - **MCP server URL:** `https://mcp.axiommath.ai/mcp`
+   - **Authentication:** paste the API key from step 1 as the bearer token.
+4. Save, then enable Axle in your chat's tools menu.

--- a/README.md
+++ b/README.md
@@ -57,15 +57,3 @@ this once; after setup, Axle is available in every future conversation.
 7. In any chat, open the tools menu (the **+** or paperclip icon in the
    composer) → **Connectors** → toggle **Axle** on. You should see the Axle
    tools listed.
-
-### ChatGPT (web / mobile)
-
-Custom MCP connectors require a paid plan (Plus, Pro, Business, or Enterprise).
-
-1. Open ChatGPT → **Settings** → **Connectors**.
-2. Click **Add** (or **Create**) and choose the custom / MCP option.
-3. Fill in:
-   - **Name:** `Axle`
-   - **MCP server URL:** `https://mcp.axiommath.ai/mcp`
-   - **Authentication:** paste the API key from step 1 as the bearer token.
-4. Save, then enable Axle in your chat's tools menu.

--- a/axle_mcp_server/server.py
+++ b/axle_mcp_server/server.py
@@ -252,7 +252,7 @@ def _build_http_app() -> Any:
     from starlette.applications import Starlette
     from starlette.requests import Request
     from starlette.responses import JSONResponse
-    from starlette.routing import Mount, Route
+    from starlette.routing import Route
 
     session_manager = StreamableHTTPSessionManager(
         app=server,
@@ -285,13 +285,21 @@ def _build_http_app() -> Any:
         async with session_manager.run():
             yield
 
-    return Starlette(
-        routes=[
-            Route("/", health, methods=["GET"]),
-            Mount("/mcp", app=handle_mcp),
-        ],
+    starlette_app = Starlette(
+        routes=[Route("/", health, methods=["GET"])],
         lifespan=lifespan,
     )
+
+    # ASGI wrapper: route /mcp (with or without trailing slash) straight to the
+    # MCP handler. Skipping Starlette's Mount avoids a 307 redirect on /mcp
+    # that Claude's web connector doesn't follow on POST.
+    async def app(scope: Any, receive: Any, send: Any) -> None:
+        if scope.get("type") == "http" and scope.get("path") in ("/mcp", "/mcp/"):
+            await handle_mcp(scope, receive, send)
+            return
+        await starlette_app(scope, receive, send)
+
+    return app
 
 
 def _http_main(host: str, port: int) -> None:

--- a/axle_mcp_server/server.py
+++ b/axle_mcp_server/server.py
@@ -4,7 +4,9 @@ Copyright (c) 2026 Axiom Math. MIT License.
 """
 from __future__ import annotations
 
+import argparse
 import asyncio
+import contextvars
 import importlib.metadata
 import json
 import logging
@@ -22,6 +24,15 @@ logger = logging.getLogger(__name__)
 VERSION: Final[str] = importlib.metadata.version("axiom-axle-mcp")
 AXLE_API_URL: Final[str] = os.environ.get("AXLE_API_URL", "https://axle.axiommath.ai")
 AXLE_API_KEY: Final[str | None] = os.environ.get("AXLE_API_KEY")
+
+# Populated per HTTP request by the streamable-HTTP wrapper. Unused in stdio mode,
+# where authentication comes from the AXLE_API_KEY env var instead.
+_request_authorization: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "axle_request_authorization", default=None
+)
+_request_client_ip: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "axle_request_client_ip", default=None
+)
 
 TYPE_MAP: Final[dict[str, dict[str, Any]]] = {
     "text": {"type": "string"},
@@ -45,8 +56,17 @@ class InputField(TypedDict, total=False):
 
 def _headers() -> dict[str, str]:
     h: dict[str, str] = {"X-Request-Source": f"axiom-axle-mcp/{VERSION}"}
-    if AXLE_API_KEY:
-        h["Authorization"] = f"Bearer {AXLE_API_KEY}"
+    # Per-request auth (HTTP mode) wins over the stdio env-var fallback.
+    auth = _request_authorization.get()
+    if auth is None and AXLE_API_KEY:
+        auth = f"Bearer {AXLE_API_KEY}"
+    if auth:
+        h["Authorization"] = auth
+    client_ip = _request_client_ip.get()
+    if client_ip:
+        # AXLE may use this to attribute anonymous requests to end-user IPs
+        # when our Cloud Run egress is on its trusted-proxy list.
+        h["X-Forwarded-For"] = client_ip
     return h
 
 
@@ -198,7 +218,7 @@ async def handle_call_tool(
     return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
 
-async def _amain() -> None:
+async def _stdio_main() -> None:
     async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
         await server.run(
             read_stream,
@@ -207,8 +227,104 @@ async def _amain() -> None:
         )
 
 
+def _extract_request_context(scope: Any) -> tuple[str | None, str | None]:
+    """Pull Authorization + first X-Forwarded-For hop from an ASGI scope."""
+    authorization: str | None = None
+    client_ip: str | None = None
+    for name, value in scope.get("headers", []):
+        lname = name.decode("latin-1").lower()
+        if lname == "authorization":
+            authorization = value.decode("latin-1")
+        elif lname == "x-forwarded-for" and client_ip is None:
+            client_ip = value.decode("latin-1").split(",", 1)[0].strip() or None
+    if client_ip is None:
+        client = scope.get("client")
+        if client:
+            client_ip = client[0]
+    return authorization, client_ip
+
+
+def _build_http_app() -> Any:
+    """Construct the Starlette ASGI app that serves MCP over streamable HTTP."""
+    from contextlib import asynccontextmanager
+
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+    from starlette.routing import Mount, Route
+
+    session_manager = StreamableHTTPSessionManager(
+        app=server,
+        event_store=None,
+        stateless=True,
+    )
+
+    async def handle_mcp(scope: Any, receive: Any, send: Any) -> None:
+        authorization, client_ip = _extract_request_context(scope)
+        auth_token = _request_authorization.set(authorization)
+        ip_token = _request_client_ip.set(client_ip)
+        try:
+            await session_manager.handle_request(scope, receive, send)
+        finally:
+            _request_authorization.reset(auth_token)
+            _request_client_ip.reset(ip_token)
+
+    async def health(_request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "service": "axle-mcp-server",
+                "version": VERSION,
+                "upstream": AXLE_API_URL,
+                "mcp_endpoint": "/mcp",
+            }
+        )
+
+    @asynccontextmanager
+    async def lifespan(_app: Starlette) -> Any:
+        async with session_manager.run():
+            yield
+
+    return Starlette(
+        routes=[
+            Route("/", health, methods=["GET"]),
+            Mount("/mcp", app=handle_mcp),
+        ],
+        lifespan=lifespan,
+    )
+
+
+def _http_main(host: str, port: int) -> None:
+    import uvicorn
+
+    app = _build_http_app()
+    uvicorn.run(app, host=host, port=port, log_level="info")
+
+
 def main() -> None:
-    asyncio.run(_amain())
+    parser = argparse.ArgumentParser(prog="axle-mcp-server")
+    parser.add_argument(
+        "--http",
+        action="store_true",
+        help="Serve MCP over streamable HTTP instead of stdio (for hosted deployments).",
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="HTTP bind address (default: 0.0.0.0). Ignored in stdio mode.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("PORT", "8080")),
+        help="HTTP port (default: $PORT or 8080). Ignored in stdio mode.",
+    )
+    args = parser.parse_args()
+
+    if args.http:
+        _http_main(args.host, args.port)
+    else:
+        asyncio.run(_stdio_main())
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,13 @@ dependencies = [
     "mcp>=1.2.0",
 ]
 
+[project.optional-dependencies]
+http = [
+    "mcp>=1.20.0",
+    "starlette>=0.40",
+    "uvicorn>=0.30",
+]
+
 [project.scripts]
 axle-mcp-server = "axle_mcp_server.server:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axiom-axle-mcp"
-version = "0.1.5"
+version = "0.2.0"
 description = "MCP server for Axiom Lean Engine (AXLE) — exposes Lean verification tools to Claude Code and other MCP clients"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from axle_mcp_server import server as srv
+
+
+def test_headers_no_auth_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(srv, "AXLE_API_KEY", None)
+    h = srv._headers()
+    assert "Authorization" not in h
+    assert "X-Forwarded-For" not in h
+    assert h["X-Request-Source"].startswith("axiom-axle-mcp/")
+
+
+def test_headers_uses_env_key_in_stdio_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(srv, "AXLE_API_KEY", "env-key")
+    assert srv._headers()["Authorization"] == "Bearer env-key"
+
+
+def test_headers_request_context_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(srv, "AXLE_API_KEY", "env-key")
+    auth_token = srv._request_authorization.set("Bearer user-key")
+    ip_token = srv._request_client_ip.set("203.0.113.7")
+    try:
+        h = srv._headers()
+    finally:
+        srv._request_authorization.reset(auth_token)
+        srv._request_client_ip.reset(ip_token)
+    assert h["Authorization"] == "Bearer user-key"
+    assert h["X-Forwarded-For"] == "203.0.113.7"
+
+
+def test_extract_request_context_reads_headers_and_client() -> None:
+    scope = {
+        "headers": [
+            (b"authorization", b"Bearer abc123"),
+            (b"x-forwarded-for", b"198.51.100.4, 10.0.0.1"),
+            (b"content-type", b"application/json"),
+        ],
+        "client": ("10.0.0.5", 54321),
+    }
+    auth, ip = srv._extract_request_context(scope)
+    assert auth == "Bearer abc123"
+    assert ip == "198.51.100.4"
+
+
+def test_extract_request_context_falls_back_to_client() -> None:
+    scope = {"headers": [], "client": ("192.0.2.9", 1234)}
+    auth, ip = srv._extract_request_context(scope)
+    assert auth is None
+    assert ip == "192.0.2.9"


### PR DESCRIPTION
Adds an optional --http mode that serves MCP over streamable HTTP with per-request Authorization / X-Forwarded-For forwarding, so a single hosted instance can serve Claude web / ChatGPT users under their own AXLE keys. Ships a Dockerfile + Cloud Run deploy notes; the existing stdio path  for uvx / Claude Code users is unchanged.

This feature was suggested by Andrew Sutherland.