### PR TITLE
Add `AXLE_DEFAULT_ENVIRONMENT` override

### DIFF
--- a/axle_mcp_server/server.py
+++ b/axle_mcp_server/server.py
@@ -284,9 +284,29 @@ def _default_environment(environments: list[dict[str, Any]]) -> str:
     return best_name
 
 
+def _resolve_default_environment(environments: list[dict[str, Any]]) -> str:
+    """Pick the default environment, honoring `AXLE_DEFAULT_ENVIRONMENT`.
+
+    If the env var names a registered environment (e.g. `pnt-4.26.0`), use
+    it. Otherwise fall back to `_default_environment`'s latest stable
+    `lean-4.X.Y`. An unknown override raises so typos fail loudly at
+    startup rather than silently routing to the auto-picked env.
+    """
+    override = (os.environ.get("AXLE_DEFAULT_ENVIRONMENT") or "").strip()
+    if not override:
+        return _default_environment(environments)
+    known = {e["name"] for e in environments}
+    if override not in known:
+        raise RuntimeError(
+            f"AXLE_DEFAULT_ENVIRONMENT={override!r} is not a registered "
+            f"environment. Known: {sorted(known)}"
+        )
+    return override
+
+
 ENDPOINTS: Final[dict[str, Any]] = _fetch_json("/v1/endpoints")
 ENVIRONMENTS: Final[list[dict[str, Any]]] = _fetch_json("/v1/environments")
-DEFAULT_ENVIRONMENT: Final[str] = _default_environment(ENVIRONMENTS)
+DEFAULT_ENVIRONMENT: Final[str] = _resolve_default_environment(ENVIRONMENTS)
 TOOL_DEFS: Final[list[types.Tool]] = _build_tool_defs(ENDPOINTS, DEFAULT_ENVIRONMENT)
 ENDPOINT_NAMES: Final[set[str]] = (
     {t.name for t in TOOL_DEFS} - {"list_environments", "share_url", "read_share_url"}

--- a/tests/test_default_environment.py
+++ b/tests/test_default_environment.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from axle_mcp_server.server import _default_environment
+import pytest
+
+from axle_mcp_server.server import _default_environment, _resolve_default_environment
 
 
 def test_selects_latest_stable_version():
@@ -43,3 +45,37 @@ def test_falls_back_to_last_when_no_match():
         {"name": "custom-env"},
     ]
     assert _default_environment(envs) == "custom-env"
+
+
+# `_resolve_default_environment` layers an `AXLE_DEFAULT_ENVIRONMENT`
+# override on top of `_default_environment`'s auto-pick.
+
+def test_resolve_falls_back_to_auto_pick_when_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("AXLE_DEFAULT_ENVIRONMENT", raising=False)
+    envs = [{"name": "lean-4.27.0"}, {"name": "lean-4.29.0"}]
+    assert _resolve_default_environment(envs) == "lean-4.29.0"
+
+
+def test_resolve_uses_override_when_set_to_known_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AXLE_DEFAULT_ENVIRONMENT", "pnt-4.28.0")
+    envs = [{"name": "lean-4.28.0"}, {"name": "pnt-4.28.0"}]
+    assert _resolve_default_environment(envs) == "pnt-4.28.0"
+
+
+def test_resolve_treats_empty_override_as_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AXLE_DEFAULT_ENVIRONMENT", "")
+    envs = [{"name": "lean-4.28.0"}]
+    assert _resolve_default_environment(envs) == "lean-4.28.0"
+
+
+def test_resolve_strips_whitespace_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AXLE_DEFAULT_ENVIRONMENT", "  pnt-4.28.0  ")
+    envs = [{"name": "lean-4.28.0"}, {"name": "pnt-4.28.0"}]
+    assert _resolve_default_environment(envs) == "pnt-4.28.0"
+
+
+def test_resolve_rejects_unknown_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AXLE_DEFAULT_ENVIRONMENT", "lean-99.99.99")
+    envs = [{"name": "lean-4.28.0"}]
+    with pytest.raises(RuntimeError, match=r"not a registered environment"):
+        _resolve_default_environment(envs)


### PR DESCRIPTION
Set this to pin the default environment to any registered name. Unset preserves current behavior (latest stable `lean-4.X.Y`). Unknown values raise at import so typos don't silently route to the auto-pick.

Tests: unset, known, empty, whitespace-padded, unknown.
