### PR TITLE
Add file_uri for stdio-mode file passthrough

### DIFF
--- a/axle_mcp_server/server.py
+++ b/axle_mcp_server/server.py
@@ -11,8 +11,10 @@ import importlib.metadata
 import json
 import logging
 import os
+import pathlib
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, Final, TypedDict
 
@@ -34,6 +36,15 @@ _request_authorization: contextvars.ContextVar[str | None] = contextvars.Context
 _request_client_ip: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "axle_request_client_ip", default=None
 )
+
+
+# Process config, set once by main(). Alternative: a _build_server builder
+# whose handlers close over the flag.
+class _Config:
+    http_mode: bool = False
+
+
+_config = _Config()
 
 TYPE_MAP: Final[dict[str, dict[str, Any]]] = {
     "text": {"type": "string"},
@@ -152,6 +163,89 @@ async def _get_shared_link(request_id: str) -> dict[str, Any]:
     return await asyncio.to_thread(_do)
 
 
+def _has_textarea_content(inputs: list[InputField]) -> bool:
+    return any(
+        f.get("name") == "content" and f.get("type") == "textarea" for f in inputs
+    )
+
+
+def _inject_file_uri(schema: dict[str, Any]) -> dict[str, Any]:
+    """Add file_uri as an alternative to content; encode the choice with oneOf."""
+    schema["properties"]["file_uri"] = {
+        "type": "string",
+        "format": "uri",
+        "description": (
+            "file:// URI or absolute path. The server reads the file locally "
+            "and sends it as `content`. Use exactly one of `content` or "
+            "`file_uri`. Stdio mode only."
+        ),
+    }
+    schema["required"] = [r for r in schema.get("required", []) if r != "content"]
+    schema["oneOf"] = [
+        {"required": ["content"]},
+        {"required": ["file_uri"]},
+    ]
+    return schema
+
+
+def _uri_to_path(uri: str) -> pathlib.Path:
+    """Accept a file:// URI or a bare absolute path. Resolves symlinks."""
+    if uri.startswith("file://"):
+        parsed = urllib.parse.urlparse(uri)
+        return pathlib.Path(urllib.request.url2pathname(parsed.path)).resolve()
+    return pathlib.Path(uri).resolve()
+
+
+async def _client_roots() -> list[pathlib.Path] | None:
+    """Resolve the client's declared MCP roots.
+
+    Returns None if the client has no roots capability (unconstrained),
+    [] if the capability is declared but no roots are set (deny all),
+    or the list of declared roots otherwise.
+    """
+    try:
+        session = server.request_context.session
+    except LookupError:
+        return None
+    if not session.check_client_capability(
+        types.ClientCapabilities(roots=types.RootsCapability())
+    ):
+        return None
+    result = await session.list_roots()
+    return [_uri_to_path(str(r.uri)) for r in result.roots]
+
+
+async def _resolve_file_uri(
+    tool_schema: dict[str, Any], arguments: dict[str, Any]
+) -> None:
+    """Replace file_uri in arguments with content read from disk. In-place."""
+    uri = arguments.pop("file_uri", None)
+    if uri is None:
+        return
+    if "file_uri" not in tool_schema.get("properties", {}):
+        raise ValueError("file_uri is not accepted by this tool")
+    if _config.http_mode:
+        raise ValueError("file_uri is only supported in stdio mode")
+    if not isinstance(uri, str) or not uri:
+        raise ValueError("file_uri must be a non-empty string")
+    if arguments.get("content") is not None:
+        raise ValueError("provide exactly one of content or file_uri")
+
+    path = _uri_to_path(uri)
+    if not path.is_file():
+        raise ValueError(f"file_uri does not point to a regular file: {uri}")
+
+    roots = await _client_roots()
+    if roots is not None and not any(
+        path == r or r in path.parents for r in roots
+    ):
+        raise ValueError(
+            f"file_uri is outside the client's declared MCP roots: {uri}"
+        )
+
+    arguments["content"] = await asyncio.to_thread(path.read_text)
+
+
 def field_to_json_schema(field: InputField) -> dict[str, Any]:
     field_type = field.get("type", "text")
     schema = dict(TYPE_MAP.get(field_type, {"type": "string"}))
@@ -195,15 +289,22 @@ def build_input_schema(
     return schema
 
 
-def _build_tool_defs(endpoints: dict[str, Any], default_environment: str) -> list[types.Tool]:
-    tools = [
-        types.Tool(
-            name=name,
-            description=meta.get("description", name),
-            inputSchema=build_input_schema(meta.get("inputs", []), default_environment),
+def _build_tool_defs(
+    endpoints: dict[str, Any], default_environment: str
+) -> list[types.Tool]:
+    tools: list[types.Tool] = []
+    for name, meta in endpoints.items():
+        inputs = meta.get("inputs", [])
+        schema = build_input_schema(inputs, default_environment)
+        if _has_textarea_content(inputs):
+            schema = _inject_file_uri(schema)
+        tools.append(
+            types.Tool(
+                name=name,
+                description=meta.get("description", name),
+                inputSchema=schema,
+            )
         )
-        for name, meta in endpoints.items()
-    ]
     tools.append(
         types.Tool(
             name="list_environments",
@@ -375,6 +476,9 @@ async def handle_call_tool(
     if name not in ENDPOINT_NAMES:
         raise ValueError(f"Unknown tool: {name}")
 
+    tool_schema = next(t.inputSchema for t in TOOL_DEFS if t.name == name)
+    await _resolve_file_uri(tool_schema, arguments)
+
     if "environment" not in arguments:
         arguments["environment"] = DEFAULT_ENVIRONMENT
 
@@ -495,6 +599,8 @@ def main() -> None:
         help="HTTP port (default: $PORT or 8080). Ignored in stdio mode.",
     )
     args = parser.parse_args()
+
+    _config.http_mode = args.http
 
     if args.http:
         _http_main(args.host, args.port)

--- a/tests/test_file_uri.py
+++ b/tests/test_file_uri.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import axle_mcp_server.server as srv
+from axle_mcp_server.server import _build_tool_defs, handle_call_tool
+
+
+def test_schema_injects_file_uri_for_content_endpoints() -> None:
+    defs = _build_tool_defs(
+        {
+            "check": {
+                "inputs": [
+                    {"name": "content", "type": "textarea", "required": True},
+                    {"name": "environment", "type": "text", "required": True},
+                ]
+            }
+        },
+        "lean-4.28.0",
+    )
+    schema = next(t.inputSchema for t in defs if t.name == "check")
+    assert "file_uri" in schema["properties"]
+    assert schema["properties"]["file_uri"]["type"] == "string"
+    assert schema["properties"]["file_uri"]["format"] == "uri"
+    assert schema["oneOf"] == [
+        {"required": ["content"]},
+        {"required": ["file_uri"]},
+    ]
+    assert "content" not in schema.get("required", [])
+
+
+def test_schema_omits_file_uri_for_non_content_endpoints() -> None:
+    defs = _build_tool_defs(
+        {
+            "merge": {
+                "inputs": [
+                    {"name": "documents", "type": "textarea_list", "required": True},
+                ]
+            }
+        },
+        "lean-4.28.0",
+    )
+    schema = next(t.inputSchema for t in defs if t.name == "merge")
+    assert "file_uri" not in schema["properties"]
+    assert "oneOf" not in schema
+
+
+async def test_file_uri_substitutes_into_content(tmp_path: pathlib.Path) -> None:
+    f = tmp_path / "p.lean"
+    f.write_text("theorem x : 1 = 1 := rfl")
+    mock = AsyncMock(return_value={"okay": True})
+    with patch("axle_mcp_server.server._call_endpoint", mock):
+        await handle_call_tool("check", {"file_uri": f.as_uri()})
+
+    sent: dict[str, Any] = mock.call_args[0][1]
+    assert sent["content"] == "theorem x : 1 = 1 := rfl"
+    assert "file_uri" not in sent
+    assert sent["environment"] == "lean-4.28.0"
+
+
+async def test_file_uri_accepts_bare_absolute_path(tmp_path: pathlib.Path) -> None:
+    f = tmp_path / "p.lean"
+    f.write_text("ok")
+    mock = AsyncMock(return_value={"okay": True})
+    with patch("axle_mcp_server.server._call_endpoint", mock):
+        await handle_call_tool("check", {"file_uri": str(f)})
+
+    assert mock.call_args[0][1]["content"] == "ok"
+
+
+async def test_rejects_both_content_and_file_uri(tmp_path: pathlib.Path) -> None:
+    f = tmp_path / "p.lean"
+    f.write_text("y")
+    with pytest.raises(ValueError, match="exactly one"):
+        await handle_call_tool(
+            "check", {"content": "x", "file_uri": f.as_uri()}
+        )
+
+
+async def test_rejects_missing_file() -> None:
+    with pytest.raises(ValueError, match="regular file"):
+        await handle_call_tool(
+            "check", {"file_uri": "file:///definitely/does/not/exist.lean"}
+        )
+
+
+async def test_rejects_directory(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(ValueError, match="regular file"):
+        await handle_call_tool("check", {"file_uri": tmp_path.as_uri()})
+
+
+async def test_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        await handle_call_tool("check", {"file_uri": ""})
+
+
+async def test_rejects_file_outside_declared_roots(
+    tmp_path: pathlib.Path,
+) -> None:
+    inside = tmp_path / "inside"
+    inside.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    f = outside / "p.lean"
+    f.write_text("x")
+    with patch(
+        "axle_mcp_server.server._client_roots",
+        AsyncMock(return_value=[inside.resolve()]),
+    ):
+        with pytest.raises(ValueError, match="outside.*roots"):
+            await handle_call_tool("check", {"file_uri": f.as_uri()})
+
+
+async def test_accepts_file_inside_declared_roots(
+    tmp_path: pathlib.Path,
+) -> None:
+    f = tmp_path / "p.lean"
+    f.write_text("ok")
+    mock = AsyncMock(return_value={"okay": True})
+    with patch(
+        "axle_mcp_server.server._client_roots",
+        AsyncMock(return_value=[tmp_path.resolve()]),
+    ), patch("axle_mcp_server.server._call_endpoint", mock):
+        await handle_call_tool("check", {"file_uri": f.as_uri()})
+
+    assert mock.call_args[0][1]["content"] == "ok"
+
+
+async def test_empty_roots_list_denies_all(tmp_path: pathlib.Path) -> None:
+    f = tmp_path / "p.lean"
+    f.write_text("x")
+    with patch(
+        "axle_mcp_server.server._client_roots", AsyncMock(return_value=[])
+    ):
+        with pytest.raises(ValueError, match="outside.*roots"):
+            await handle_call_tool("check", {"file_uri": f.as_uri()})
+
+
+async def test_http_mode_rejects_file_uri(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(srv._config, "http_mode", True)
+    f = tmp_path / "p.lean"
+    f.write_text("x")
+    with pytest.raises(ValueError, match="stdio mode"):
+        await handle_call_tool("check", {"file_uri": f.as_uri()})


### PR DESCRIPTION
Adds a `file_uri` parameter on every AXLE tool that takes Lean source. When an agent passes `file_uri: "file:///work/p.lean"`, the local MCP subprocess reads the file and forwards its contents to AXLE as `content`. Per-iteration tool-call args drop from ~200k tokens of inlined source to ~50.

Stdio only, the hosted server rejects `file_uri` at runtime (its filesystem isn't the agent's). MCP roots are honored when declared. Schema uses `oneOf` to make `content` and `file_uri` mutually exclusive.

Existing calls that pass `content` are unchanged. No AXLE-side changes, no new deps.