### PR TITLE
Fix file_uri schema: drop top-level oneOf that breaks Anthropic/Vertex

### DIFF
--- a/axle_mcp_server/server.py
+++ b/axle_mcp_server/server.py
@@ -170,21 +170,28 @@ def _has_textarea_content(inputs: list[InputField]) -> bool:
 
 
 def _inject_file_uri(schema: dict[str, Any]) -> dict[str, Any]:
-    """Add file_uri as an alternative to content; encode the choice with oneOf."""
+    """Add `file_uri` as an optional alternative to `content`.
+
+    The "exactly one of content/file_uri" rule is enforced server-side in
+    `_resolve_file_uri`, not via a top-level oneOf: the Anthropic Messages API
+    (and Vertex via OpenRouter) reject oneOf/anyOf/allOf in a tool's
+    input_schema outright.
+    """
     schema["properties"]["file_uri"] = {
         "type": "string",
         "format": "uri",
         "description": (
             "file:// URI or absolute path. The server reads the file locally "
-            "and sends it as `content`. Use exactly one of `content` or "
+            "and sends it as `content`. Provide exactly one of `content` or "
             "`file_uri`. Stdio mode only."
         ),
     }
-    schema["required"] = [r for r in schema.get("required", []) if r != "content"]
-    schema["oneOf"] = [
-        {"required": ["content"]},
-        {"required": ["file_uri"]},
-    ]
+    # content is no longer required; file_uri can satisfy the call instead.
+    required = [r for r in schema.get("required", []) if r != "content"]
+    if required:
+        schema["required"] = required
+    else:
+        schema.pop("required", None)
     return schema
 
 
@@ -218,11 +225,18 @@ async def _client_roots() -> list[pathlib.Path] | None:
 async def _resolve_file_uri(
     tool_schema: dict[str, Any], arguments: dict[str, Any]
 ) -> None:
-    """Replace file_uri in arguments with content read from disk. In-place."""
+    """Replace file_uri in arguments with content read from disk. In-place.
+
+    Enforces "exactly one of content/file_uri" for content endpoints, since the
+    schema no longer encodes it (see `_inject_file_uri`).
+    """
+    accepts_file_uri = "file_uri" in tool_schema.get("properties", {})
     uri = arguments.pop("file_uri", None)
     if uri is None:
+        if accepts_file_uri and arguments.get("content") is None:
+            raise ValueError("provide exactly one of content or file_uri")
         return
-    if "file_uri" not in tool_schema.get("properties", {}):
+    if not accepts_file_uri:
         raise ValueError("file_uri is not accepted by this tool")
     if _config.http_mode:
         raise ValueError("file_uri is only supported in stdio mode")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axiom-axle-mcp"
-version = "0.3.4"
+version = "0.3.5"
 description = "MCP server for Axiom Lean Engine (AXLE) — exposes Lean verification tools to Claude Code and other MCP clients"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_file_uri.py
+++ b/tests/test_file_uri.py
@@ -26,10 +26,8 @@ def test_schema_injects_file_uri_for_content_endpoints() -> None:
     assert "file_uri" in schema["properties"]
     assert schema["properties"]["file_uri"]["type"] == "string"
     assert schema["properties"]["file_uri"]["format"] == "uri"
-    assert schema["oneOf"] == [
-        {"required": ["content"]},
-        {"required": ["file_uri"]},
-    ]
+    # content drops from required: either it or file_uri satisfies the call.
+    # (No combinator is asserted here; that invariant has its own test.)
     assert "content" not in schema.get("required", [])
 
 
@@ -47,6 +45,17 @@ def test_schema_omits_file_uri_for_non_content_endpoints() -> None:
     schema = next(t.inputSchema for t in defs if t.name == "merge")
     assert "file_uri" not in schema["properties"]
     assert "oneOf" not in schema
+
+
+def test_no_tool_schema_uses_top_level_combinators() -> None:
+    # The Anthropic API (and Vertex via OpenRouter) reject oneOf/anyOf/allOf at
+    # the top level of a tool's input_schema. The full tool list ships on every
+    # request, so one bad schema fails every call, not just the offending tool.
+    # Guards all tools, including the static share/list defs.
+    for tool in srv.TOOL_DEFS:
+        for key in ("oneOf", "anyOf", "allOf"):
+            assert key not in tool.inputSchema, f"{tool.name} schema has {key}"
+        assert tool.inputSchema["type"] == "object"
 
 
 async def test_file_uri_substitutes_into_content(tmp_path: pathlib.Path) -> None:
@@ -79,6 +88,11 @@ async def test_rejects_both_content_and_file_uri(tmp_path: pathlib.Path) -> None
         await handle_call_tool(
             "check", {"content": "x", "file_uri": f.as_uri()}
         )
+
+
+async def test_rejects_neither_content_nor_file_uri() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        await handle_call_tool("check", {})
 
 
 async def test_rejects_missing_file() -> None:


### PR DESCRIPTION
- #3 encoded the content/file_uri xor with a top-level oneOf. Anthropic (and Vertex via OpenRouter) reject oneOf/anyOf/allOf in input_schema, and since the full tool list ships every request, one bad schema 400s every call.
- Made content/file_uri plain optional props; enforce the xor server-side in _resolve_file_uri (rejects both and neither with a clear error).
- Added a regression test: no tool schema carries a top-level combinator.
- No change for callers passing content; no AXLE-side changes, no new deps.