### PR TITLE
Add brief/verbose output mode to endpoint tools

### DIFF
--- a/axle_mcp_server/server.py
+++ b/axle_mcp_server/server.py
@@ -303,22 +303,6 @@ def build_input_schema(
     return schema
 
 
-def _inject_verbosity(schema: dict[str, Any]) -> dict[str, Any]:
-    """Add the server-side `verbosity` knob to an endpoint's input schema."""
-    schema["properties"]["verbosity"] = {
-        "type": "string",
-        "enum": ["brief", "verbose"],
-        "default": "verbose",
-        "description": (
-            "Output detail level. \"verbose\" (default): the raw AXLE response, "
-            "pretty-printed. \"brief\": drops timings, empty message buckets, and "
-            "content that just echoes the input; emits compact JSON. Keeps all "
-            "errors/warnings/infos. Use \"brief\" to save tokens."
-        ),
-    }
-    return schema
-
-
 def _build_tool_defs(
     endpoints: dict[str, Any], default_environment: str
 ) -> list[types.Tool]:
@@ -328,7 +312,18 @@ def _build_tool_defs(
         schema = build_input_schema(inputs, default_environment)
         if _has_textarea_content(inputs):
             schema = _inject_file_uri(schema)
-        schema = _inject_verbosity(schema)
+        schema["properties"]["verbosity"] = {
+            "type": "string",
+            "enum": ["brief", "verbose"],
+            "default": "verbose",
+            "description": (
+                "Output detail level. \"verbose\" (default): the raw AXLE response, "
+                "pretty-printed. \"brief\": compact JSON; drops timings and empty "
+                "message buckets (non-empty errors/warnings/infos always survive), "
+                "and replaces content that just echoes the input with "
+                "content_unchanged=true. Use \"brief\" to save tokens."
+            ),
+        }
         tools.append(
             types.Tool(
                 name=name,
@@ -455,18 +450,7 @@ def _extract_request_id(share_url: str) -> str | None:
     return m.group(0) if m else None
 
 
-def _brief_messages(bucket: dict[str, Any]) -> dict[str, Any] | None:
-    """Keep non-empty errors/warnings/infos; None when all three are empty.
-
-    infos carries the Escher agent's `exact?`/`apply?`/`rw?` "Try this:"
-    suggestions and `#eval`/`#check` output, so it stays.
-    """
-    out = {k: bucket[k] for k in ("errors", "warnings", "infos") if bucket.get(k)}
-    return out or None
-
-
 def _briefen(result: Any, submitted_content: str | None) -> Any:
-    """Drop timings, empty buckets, and echoed-back content from a response."""
     if not isinstance(result, dict):
         return result
     out: dict[str, Any] = {}
@@ -474,21 +458,16 @@ def _briefen(result: Any, submitted_content: str | None) -> Any:
         if key == "timings":
             continue
         if key in ("lean_messages", "tool_messages") and isinstance(value, dict):
-            brief = _brief_messages(value)
-            if brief is not None:
-                out[key] = brief
+            kept = {k: value[k] for k in ("errors", "warnings", "infos") if value.get(k)}
+            if kept:
+                out[key] = kept
             continue
         if key == "content" and submitted_content is not None and value == submitted_content:
+            out["content_unchanged"] = True
             continue
         out[key] = value
     return out
 
-
-def _serialize_result(result: Any, verbosity: str, submitted_content: str | None) -> str:
-    """Render an endpoint response as text, honoring the verbosity level."""
-    if verbosity == "brief":
-        return json.dumps(_briefen(result, submitted_content), separators=(",", ":"))
-    return json.dumps(result, indent=2)
 
 server = Server("axle")
 
@@ -543,7 +522,6 @@ async def handle_call_tool(
     if name not in ENDPOINT_NAMES:
         raise ValueError(f"Unknown tool: {name}")
 
-    # Server-side knob; not forwarded to the API.
     verbosity = arguments.pop("verbosity", "verbose")
 
     tool_schema = next(t.inputSchema for t in TOOL_DEFS if t.name == name)
@@ -556,7 +534,10 @@ async def handle_call_tool(
 
     result = await _call_endpoint(name, request)
 
-    text = _serialize_result(result, verbosity, arguments.get("content"))
+    if verbosity == "brief":
+        text = json.dumps(_briefen(result, arguments.get("content")), separators=(",", ":"))
+    else:
+        text = json.dumps(result, indent=2)
     return [types.TextContent(type="text", text=text)]
 
 

--- a/axle_mcp_server/server.py
+++ b/axle_mcp_server/server.py
@@ -303,6 +303,22 @@ def build_input_schema(
     return schema
 
 
+def _inject_verbosity(schema: dict[str, Any]) -> dict[str, Any]:
+    """Add the server-side `verbosity` knob to an endpoint's input schema."""
+    schema["properties"]["verbosity"] = {
+        "type": "string",
+        "enum": ["brief", "verbose"],
+        "default": "verbose",
+        "description": (
+            "Output detail level. \"verbose\" (default): the raw AXLE response, "
+            "pretty-printed. \"brief\": drops timings, empty message buckets, and "
+            "content that just echoes the input; emits compact JSON. Keeps all "
+            "errors/warnings/infos. Use \"brief\" to save tokens."
+        ),
+    }
+    return schema
+
+
 def _build_tool_defs(
     endpoints: dict[str, Any], default_environment: str
 ) -> list[types.Tool]:
@@ -312,6 +328,7 @@ def _build_tool_defs(
         schema = build_input_schema(inputs, default_environment)
         if _has_textarea_content(inputs):
             schema = _inject_file_uri(schema)
+        schema = _inject_verbosity(schema)
         tools.append(
             types.Tool(
                 name=name,
@@ -437,6 +454,42 @@ def _extract_request_id(share_url: str) -> str | None:
     m = _UUID_RE.search(share_url)
     return m.group(0) if m else None
 
+
+def _brief_messages(bucket: dict[str, Any]) -> dict[str, Any] | None:
+    """Keep non-empty errors/warnings/infos; None when all three are empty.
+
+    infos carries the Escher agent's `exact?`/`apply?`/`rw?` "Try this:"
+    suggestions and `#eval`/`#check` output, so it stays.
+    """
+    out = {k: bucket[k] for k in ("errors", "warnings", "infos") if bucket.get(k)}
+    return out or None
+
+
+def _briefen(result: Any, submitted_content: str | None) -> Any:
+    """Drop timings, empty buckets, and echoed-back content from a response."""
+    if not isinstance(result, dict):
+        return result
+    out: dict[str, Any] = {}
+    for key, value in result.items():
+        if key == "timings":
+            continue
+        if key in ("lean_messages", "tool_messages") and isinstance(value, dict):
+            brief = _brief_messages(value)
+            if brief is not None:
+                out[key] = brief
+            continue
+        if key == "content" and submitted_content is not None and value == submitted_content:
+            continue
+        out[key] = value
+    return out
+
+
+def _serialize_result(result: Any, verbosity: str, submitted_content: str | None) -> str:
+    """Render an endpoint response as text, honoring the verbosity level."""
+    if verbosity == "brief":
+        return json.dumps(_briefen(result, submitted_content), separators=(",", ":"))
+    return json.dumps(result, indent=2)
+
 server = Server("axle")
 
 
@@ -490,6 +543,9 @@ async def handle_call_tool(
     if name not in ENDPOINT_NAMES:
         raise ValueError(f"Unknown tool: {name}")
 
+    # Server-side knob; not forwarded to the API.
+    verbosity = arguments.pop("verbosity", "verbose")
+
     tool_schema = next(t.inputSchema for t in TOOL_DEFS if t.name == name)
     await _resolve_file_uri(tool_schema, arguments)
 
@@ -500,7 +556,8 @@ async def handle_call_tool(
 
     result = await _call_endpoint(name, request)
 
-    return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+    text = _serialize_result(result, verbosity, arguments.get("content"))
+    return [types.TextContent(type="text", text=text)]
 
 
 async def _stdio_main() -> None:

--- a/tests/test_verbosity.py
+++ b/tests/test_verbosity.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from axle_mcp_server.server import _briefen, handle_call_tool
+
+_FULL_RESPONSE = {
+    "okay": False,
+    "content": "theorem foo : 1 = 1 := rfl\n",
+    "lean_messages": {"errors": [], "warnings": [], "infos": ["Try this: exact foo"]},
+    "tool_messages": {"errors": ["mismatch"], "warnings": [], "infos": []},
+    "timings": {"total_ms": 160, "candidate_ms": 28},
+    "failed_declarations": ["foo"],
+}
+
+
+def test_briefen_drops_timings_and_empty_buckets() -> None:
+    out = _briefen(_FULL_RESPONSE, submitted_content=None)
+    assert "timings" not in out
+    # tool_messages had only an error; empty warnings/infos dropped.
+    assert out["tool_messages"] == {"errors": ["mismatch"]}
+    assert out["okay"] is False
+    assert out["failed_declarations"] == ["foo"]
+
+
+def test_briefen_keeps_infos() -> None:
+    # The Escher agent reads exact?/apply?/rw? suggestions from infos.
+    out = _briefen(_FULL_RESPONSE, submitted_content=None)
+    assert out["lean_messages"] == {"infos": ["Try this: exact foo"]}
+
+
+def test_briefen_drops_echoed_content() -> None:
+    content = "theorem foo : 1 = 1 := rfl\n"
+    out = _briefen({"okay": True, "content": content}, submitted_content=content)
+    assert "content" not in out
+
+
+def test_briefen_keeps_transformed_content() -> None:
+    out = _briefen({"content": "renamed\n"}, submitted_content="original\n")
+    assert out["content"] == "renamed\n"
+
+
+def test_briefen_passthrough_non_dict() -> None:
+    assert _briefen([1, 2], submitted_content=None) == [1, 2]
+
+
+def test_verbosity_param_in_schema() -> None:
+    import axle_mcp_server.server as srv
+
+    schema = next(t.inputSchema for t in srv.TOOL_DEFS if t.name == "check")
+    assert schema["properties"]["verbosity"]["enum"] == ["brief", "verbose"]
+    assert schema["properties"]["verbosity"]["default"] == "verbose"
+    assert "verbosity" not in schema.get("required", [])
+
+
+async def test_verbosity_not_forwarded_to_api() -> None:
+    mock = AsyncMock(return_value={"okay": True})
+    with patch("axle_mcp_server.server._call_endpoint", mock):
+        await handle_call_tool("check", {"content": "x", "verbosity": "brief"})
+
+    assert "verbosity" not in mock.call_args[0][1]
+
+
+async def test_brief_output_is_compact() -> None:
+    mock = AsyncMock(return_value=_FULL_RESPONSE)
+    with patch("axle_mcp_server.server._call_endpoint", mock):
+        result = await handle_call_tool("check", {"content": "x", "verbosity": "brief"})
+
+    text = result[0].text
+    assert "\n" not in text  # compact, no indent
+    parsed = json.loads(text)
+    assert "timings" not in parsed
+
+
+async def test_full_is_default_and_pretty() -> None:
+    mock = AsyncMock(return_value=_FULL_RESPONSE)
+    with patch("axle_mcp_server.server._call_endpoint", mock):
+        result = await handle_call_tool("check", {"content": "x"})
+
+    text = result[0].text
+    assert "\n" in text  # indent=2 pretty-print
+    assert json.loads(text)["timings"]["total_ms"] == 160

--- a/tests/test_verbosity.py
+++ b/tests/test_verbosity.py
@@ -15,30 +15,26 @@ _FULL_RESPONSE = {
 }
 
 
-def test_briefen_drops_timings_and_empty_buckets() -> None:
+def test_briefen_drops_timings_and_empty_buckets_keeps_the_rest() -> None:
     out = _briefen(_FULL_RESPONSE, submitted_content=None)
     assert "timings" not in out
-    # tool_messages had only an error; empty warnings/infos dropped.
     assert out["tool_messages"] == {"errors": ["mismatch"]}
+    assert out["lean_messages"] == {"infos": ["Try this: exact foo"]}
     assert out["okay"] is False
     assert out["failed_declarations"] == ["foo"]
 
 
-def test_briefen_keeps_infos() -> None:
-    # The Escher agent reads exact?/apply?/rw? suggestions from infos.
-    out = _briefen(_FULL_RESPONSE, submitted_content=None)
-    assert out["lean_messages"] == {"infos": ["Try this: exact foo"]}
-
-
-def test_briefen_drops_echoed_content() -> None:
+def test_briefen_flags_echoed_content() -> None:
     content = "theorem foo : 1 = 1 := rfl\n"
     out = _briefen({"okay": True, "content": content}, submitted_content=content)
     assert "content" not in out
+    assert out["content_unchanged"] is True
 
 
 def test_briefen_keeps_transformed_content() -> None:
     out = _briefen({"content": "renamed\n"}, submitted_content="original\n")
     assert out["content"] == "renamed\n"
+    assert "content_unchanged" not in out
 
 
 def test_briefen_passthrough_non_dict() -> None:
@@ -68,9 +64,8 @@ async def test_brief_output_is_compact() -> None:
         result = await handle_call_tool("check", {"content": "x", "verbosity": "brief"})
 
     text = result[0].text
-    assert "\n" not in text  # compact, no indent
-    parsed = json.loads(text)
-    assert "timings" not in parsed
+    assert "\n" not in text
+    assert "timings" not in json.loads(text)
 
 
 async def test_full_is_default_and_pretty() -> None:
@@ -79,5 +74,5 @@ async def test_full_is_default_and_pretty() -> None:
         result = await handle_call_tool("check", {"content": "x"})
 
     text = result[0].text
-    assert "\n" in text  # indent=2 pretty-print
+    assert "\n" in text
     assert json.loads(text)["timings"]["total_ms"] == 160


### PR DESCRIPTION
## What

In the spirit of token-reduction -- adds an optional per-call `verbosity` parameter to every endpoint tool, so token-conscious callers can opt into a trimmed response. Mostly matters for `check`/`verify_proof`.

- `verbosity: "verbose"` (**default**) — the current behavior: raw AXLE response, pretty-printed with `indent=2`. Existing callers are unaffected.
- `verbosity: "brief"` — drops `timings`, empty message buckets, and `content` that merely echoes the submitted input; emits compact JSON.

## What brief keeps

`brief` keeps **all** non-empty `errors`/`warnings`/`infos`. The `content` drop only fires when the response echoes the input, so transformed output from `rename`/`merge`/`normalize`/etc. always survives.