### PR TITLE
Add docs endpoints to MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ manipulation tools to AI agents.
 ![](demo.gif)
 
 
+## Tools
+
+Most tools are generated from the AXLE API's `/v1/endpoints` — `verify_proof`,
+`check`, `merge`, `sorry2lemma` and friends. Alongside them the server provides:
+
+| Tool | Purpose |
+| --- | --- |
+| `read_docs` | Read the AXLE documentation. Call with no arguments for the page index, then `page="verify_proof"` for one page. |
+| `list_environments` | List the available Lean environments. |
+| `share_url` | Turn a prior call's `request_id` into a permanent shareable webapp URL. |
+| `read_share_url` | Read back the inputs and result behind a share URL. |
+
+
 ## Installation
 
 1. Create a free API key:

--- a/axle_mcp_server/server.py
+++ b/axle_mcp_server/server.py
@@ -77,7 +77,7 @@ def _headers() -> dict[str, str]:
     client_ip = _request_client_ip.get()
     if client_ip:
         # AXLE may use this to attribute anonymous requests to end-user IPs
-        # when our Cloud Run egress is on its trusted-proxy list.
+        # when our egress is on its trusted-proxy list.
         h["X-Forwarded-For"] = client_ip
     return h
 
@@ -161,6 +161,83 @@ async def _get_shared_link(request_id: str) -> dict[str, Any]:
             raise RuntimeError(f"AXLE shared-links error: {e.code} {err_body}") from None
 
     return await asyncio.to_thread(_do)
+
+
+DOCS_PATH: Final[str] = "/v1/docs"
+DOCS_ALL_PATH: Final[str] = f"{DOCS_PATH}/all.json"
+
+
+class DocPage(TypedDict):
+    slug: str
+    title: str
+    html_url: str
+    markdown: str
+
+
+_docs_cache: list[DocPage] | None = None
+_docs_lock: Final[asyncio.Lock] = asyncio.Lock()
+
+
+async def _load_docs() -> list[DocPage]:
+    """Load the docs corpus once per process."""
+    global _docs_cache
+    if _docs_cache is not None:
+        return _docs_cache
+    async with _docs_lock:
+        if _docs_cache is None:
+            _docs_cache = await asyncio.to_thread(_fetch_doc_pages)
+        return _docs_cache
+
+
+def _fetch_doc_pages() -> list[DocPage]:
+    try:
+        payload = _fetch_json(DOCS_ALL_PATH)
+    except urllib.error.HTTPError as e:
+        hint = " (these docs require an API key)" if e.code in (401, 403) else ""
+        raise RuntimeError(
+            f"Could not fetch AXLE docs from {AXLE_API_URL}{DOCS_ALL_PATH}: "
+            f"{e.code} {e.reason}{hint}"
+        ) from None
+    return _pages_from_bundle(payload)
+
+
+def _pages_from_bundle(payload: Any) -> list[DocPage]:
+    """Normalize {version, pages: [{slug, title, html_url, markdown}]}, nav order."""
+    raw = payload.get("pages") if isinstance(payload, dict) else None
+    if not isinstance(raw, list) or not raw:
+        raise RuntimeError(f"{AXLE_API_URL}{DOCS_ALL_PATH} returned no pages")
+    return [
+        DocPage(
+            slug=str(entry.get("slug", "")).strip("/"),
+            title=str(entry.get("title") or entry.get("slug") or "index"),
+            html_url=str(entry.get("html_url", "")),
+            markdown=str(entry.get("markdown", "")).strip(),
+        )
+        for entry in raw
+        if isinstance(entry, dict)
+    ]
+
+
+def _find_doc_page(ref: str, pages: list[DocPage]) -> DocPage:
+    """Resolve a slug, a bare tool name, or a docs URL onto a page."""
+    key = ref.strip().split(f"{DOCS_PATH}/", 1)[-1]
+    key = key.split("#")[0].strip("/").removesuffix(".md").lower() or "index"
+    for page in pages:
+        if (page["slug"].lower() or "index") in (key, f"tools/{key}"):
+            return page
+    known = ", ".join(p["slug"] for p in pages)
+    raise ValueError(f"Unknown docs page {ref!r}. Available pages: {known}")
+
+
+def _render_doc_index(pages: list[DocPage]) -> str:
+    lines = ["# AXLE documentation index", ""]
+    lines += [f"- `{p['slug']}` — {p['title']}" for p in pages]
+    return "\n".join(lines)
+
+
+def _render_doc_page(page: DocPage) -> str:
+    source = f"Source: {page['html_url']}\n\n" if page["html_url"] else ""
+    return f"{source}{page['markdown']}"
 
 
 def _has_textarea_content(inputs: list[InputField]) -> bool:
@@ -321,6 +398,31 @@ def _build_tool_defs(
         )
     tools.append(
         types.Tool(
+            name="read_docs",
+            description=(
+                "Read the AXLE documentation. Consult this before using an AXLE tool "
+                "on anything non-trivial: each tool has a docs page covering its input "
+                "semantics, output shape, Lean conventions and failure modes. Call with "
+                "no arguments for the page index, then with page='verify_proof' (or any "
+                "slug from that index) to read a page. Returns markdown."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "string",
+                        "description": (
+                            "Page slug from the index, e.g. 'quickstart', "
+                            "'troubleshooting', 'tools/verify_proof' (bare tool names "
+                            "like 'verify_proof' also work). Omit for the index."
+                        ),
+                    },
+                },
+            },
+        )
+    )
+    tools.append(
+        types.Tool(
             name="list_environments",
             description="List available Lean environments on the AXLE server.",
             inputSchema={"type": "object", "properties": {}},
@@ -423,9 +525,13 @@ ENDPOINTS: Final[dict[str, Any]] = _fetch_json("/v1/endpoints")
 ENVIRONMENTS: Final[list[dict[str, Any]]] = _fetch_json("/v1/environments")
 DEFAULT_ENVIRONMENT: Final[str] = _resolve_default_environment(ENVIRONMENTS)
 TOOL_DEFS: Final[list[types.Tool]] = _build_tool_defs(ENDPOINTS, DEFAULT_ENVIRONMENT)
-ENDPOINT_NAMES: Final[set[str]] = (
-    {t.name for t in TOOL_DEFS} - {"list_environments", "share_url", "read_share_url"}
-)
+BUILTIN_TOOLS: Final[set[str]] = {
+    "read_docs",
+    "list_environments",
+    "share_url",
+    "read_share_url",
+}
+ENDPOINT_NAMES: Final[set[str]] = {t.name for t in TOOL_DEFS} - BUILTIN_TOOLS
 
 _UUID_RE: Final[re.Pattern[str]] = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
@@ -451,6 +557,15 @@ async def handle_call_tool(
 ) -> list[types.TextContent]:
     if arguments is None:
         arguments = {}
+
+    if name == "read_docs":
+        pages = await _load_docs()
+        page_arg = arguments.get("page")
+        if isinstance(page_arg, str) and page_arg.strip():
+            text = _render_doc_page(_find_doc_page(page_arg, pages))
+        else:
+            text = _render_doc_index(pages)
+        return [types.TextContent(type="text", text=text)]
 
     if name == "list_environments":
         return [types.TextContent(type="text", text=json.dumps(ENVIRONMENTS, indent=2))]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axiom-axle-mcp"
-version = "0.3.5"
+version = "0.3.6"
 description = "MCP server for Axiom Lean Engine (AXLE) — exposes Lean verification tools to Claude Code and other MCP clients"
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,4 +44,4 @@ def _patch_startup_data(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(srv, "DEFAULT_ENVIRONMENT", default_env)
     tool_defs = srv._build_tool_defs(MOCK_ENDPOINTS, default_env)
     monkeypatch.setattr(srv, "TOOL_DEFS", tool_defs)
-    monkeypatch.setattr(srv, "ENDPOINT_NAMES", {t.name for t in tool_defs} - {"list_environments"})
+    monkeypatch.setattr(srv, "ENDPOINT_NAMES", {t.name for t in tool_defs} - srv.BUILTIN_TOOLS)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import urllib.error
+from typing import Any
+
+import pytest
+
+import axle_mcp_server.server as srv
+
+# Captured before the autouse fixture swaps it for a stub, so the loading tests
+# can exercise the real implementation.
+_REAL_LOAD_DOCS = srv._load_docs
+
+# Shaped like /v1/docs/all.json: manifest + inlined source markdown, nav order.
+MOCK_BUNDLE: dict[str, Any] = {
+    "version": "8f3c1d2",
+    "pages": [
+        {
+            "slug": "quickstart",
+            "title": "Quick Start",
+            "html_url": "https://axle.axiommath.ai/v1/docs/quickstart/",
+            "markdown": "# Quick Start\n\nInstall the client, then call `check`.",
+        },
+        {
+            "slug": "tools/verify_proof",
+            "title": "verify_proof",
+            "html_url": "https://docs.example.com/v1/docs/tools/verify_proof/",
+            "markdown": (
+                "# verify_proof\n\n"
+                "See [lean4checker](https://github.com/leanprover/lean4checker).\n\n"
+                "## Input Parameters\n\n### `formal_statement`\n\n"
+                "```lean\ntheorem t : 1 = 1 := by sorry\n```"
+            ),
+        },
+    ],
+}
+
+MOCK_PAGES: list[srv.DocPage] = srv._pages_from_bundle(MOCK_BUNDLE)
+
+
+@pytest.fixture(autouse=True)
+def _patch_docs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(srv, "_docs_cache", None)
+
+    async def _fake_load() -> list[srv.DocPage]:
+        return MOCK_PAGES
+
+    monkeypatch.setattr(srv, "_load_docs", _fake_load)
+
+
+async def _read_docs(**arguments: Any) -> str:
+    result = await srv.handle_call_tool("read_docs", arguments)
+    assert len(result) == 1
+    return str(result[0].text)
+
+
+def test_read_docs_is_registered_as_a_builtin() -> None:
+    tool = next(t for t in srv._build_tool_defs({}, "lean-4.28.0") if t.name == "read_docs")
+    assert set(tool.inputSchema["properties"]) == {"page"}
+    # Some model APIs reject oneOf/anyOf/allOf in a tool's input_schema.
+    assert not {"oneOf", "anyOf", "allOf", "required"} & set(tool.inputSchema)
+    assert "read_docs" in srv.BUILTIN_TOOLS
+    assert "read_docs" not in srv.ENDPOINT_NAMES
+
+
+def test_bundle_normalizes_pages_and_passes_markdown_through() -> None:
+    assert [p["slug"] for p in MOCK_PAGES] == ["quickstart", "tools/verify_proof"]
+    page = MOCK_PAGES[1]
+    assert page["title"] == "verify_proof"
+    assert page["html_url"] == "https://docs.example.com/v1/docs/tools/verify_proof/"
+    assert page["markdown"] == str(MOCK_BUNDLE["pages"][1]["markdown"])
+    assert "https://github.com/leanprover/lean4checker" in page["markdown"]
+    assert "### `formal_statement`" in page["markdown"]
+
+
+@pytest.mark.parametrize("payload", [{}, {"pages": []}, []])
+def test_bundle_rejects_unusable_payloads(payload: Any) -> None:
+    with pytest.raises(RuntimeError, match="returned no pages"):
+        srv._pages_from_bundle(payload)
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("verify_proof", "tools/verify_proof"),
+        ("tools/verify_proof/", "tools/verify_proof"),
+        ("tools/verify_proof/#input-parameters", "tools/verify_proof"),
+        ("https://axle.axiommath.ai/v1/docs/tools/verify_proof/", "tools/verify_proof"),
+        ("quickstart", "quickstart"),
+    ],
+)
+def test_find_doc_page_accepts_slugs_bare_names_and_urls(
+    given: str, expected: str
+) -> None:
+    assert srv._find_doc_page(given, MOCK_PAGES)["slug"] == expected
+
+
+def test_find_doc_page_unknown_lists_available_pages() -> None:
+    with pytest.raises(ValueError, match="Unknown docs page 'nope'") as excinfo:
+        srv._find_doc_page("nope", MOCK_PAGES)
+    assert "tools/verify_proof" in str(excinfo.value)
+
+
+async def test_no_arguments_returns_the_page_index() -> None:
+    out = await _read_docs()
+    assert "# AXLE documentation index" in out
+    assert "- `quickstart` — Quick Start" in out
+    assert "- `tools/verify_proof` — verify_proof" in out
+
+
+async def test_page_returns_markdown_verbatim_after_a_source_line() -> None:
+    out = await _read_docs(page="verify_proof")
+    assert out == (
+        "Source: https://docs.example.com/v1/docs/tools/verify_proof/\n\n"
+        f"{MOCK_PAGES[1]['markdown']}"
+    )
+
+
+async def test_blank_page_argument_falls_through_to_the_index() -> None:
+    assert "# AXLE documentation index" in await _read_docs(page="   ")
+
+
+async def test_unknown_page_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown docs page"):
+        await _read_docs(page="nope")
+
+
+async def test_load_docs_fetches_once_and_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(srv, "_docs_cache", None)
+    calls: list[str] = []
+
+    def _fake_fetch(path: str) -> Any:
+        calls.append(path)
+        return MOCK_BUNDLE
+
+    monkeypatch.setattr(srv, "_fetch_json", _fake_fetch)
+    assert await _REAL_LOAD_DOCS() == await _REAL_LOAD_DOCS() == MOCK_PAGES
+    assert calls == ["/v1/docs/all.json"]
+
+
+@pytest.mark.parametrize(
+    ("code", "match"), [(401, "require an API key"), (404, "404")]
+)
+async def test_load_docs_surfaces_http_errors(
+    monkeypatch: pytest.MonkeyPatch, code: int, match: str
+) -> None:
+    monkeypatch.setattr(srv, "_docs_cache", None)
+
+    def _fake_fetch(path: str) -> Any:
+        raise urllib.error.HTTPError(path, code, "Nope", {}, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(srv, "_fetch_json", _fake_fetch)
+    with pytest.raises(RuntimeError, match=match):
+        await _REAL_LOAD_DOCS()
+
+
+async def test_load_docs_does_not_cache_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unauthenticated first call must not poison a later authenticated one."""
+    monkeypatch.setattr(srv, "_docs_cache", None)
+    attempts: list[str] = []
+
+    def _fake_fetch(path: str) -> Any:
+        attempts.append(path)
+        if len(attempts) == 1:
+            raise urllib.error.HTTPError(path, 401, "Unauthorized", {}, None)  # type: ignore[arg-type]
+        return MOCK_BUNDLE
+
+    monkeypatch.setattr(srv, "_fetch_json", _fake_fetch)
+    with pytest.raises(RuntimeError):
+        await _REAL_LOAD_DOCS()
+    assert await _REAL_LOAD_DOCS() == MOCK_PAGES

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -100,7 +100,7 @@ async def test_read_share_url_extracts_uuid_from_full_url() -> None:
             "result": {"okay": True},
             "state": "succeeded",
             "created_at": "T",
-            "tier_saved": "alpha",
+            "extra_field": "x",
             "source": "hot_store",
         }
     )
@@ -114,7 +114,7 @@ async def test_read_share_url_extracts_uuid_from_full_url() -> None:
     parsed = json.loads(result[0].text)
     assert parsed["tool_name"] == "verify_proof"
     assert parsed["state"] == "succeeded"
-    assert "tier_saved" not in parsed
+    assert "extra_field" not in parsed
     assert "source" not in parsed
 
 


### PR DESCRIPTION
Uses the new raw docs endpoints to retrieve machine-readable docs.